### PR TITLE
Fix: neutralize anti-devtool false-positive blanking on TV (closes #2)

### DIFF
--- a/mods/antiDevtool.js
+++ b/mods/antiDevtool.js
@@ -1,0 +1,37 @@
+// Cineby bundles disable-devtool@0.3.8, whose Performance detector false-positives on TV
+// hardware and never stops polling (its pc/mobile stop-gate misclassifies Tizen as desktop).
+// The console stub below is resolved per-call by the library, so it works even though this
+// script runs before disable-devtool initializes. window.open/setTimeout are a safety net in
+// case a detector fires anyway.
+
+const nativeLog = console.log.bind(console);
+const nativeOpen = window.open;
+const nativeSetTimeout = window.setTimeout;
+
+console.log = function () {};
+console.table = function () {};
+console.clear = function () {};
+
+window.open = function (url, target) {
+  if ((!url || url === 'about:blank') && target === '_self') {
+    nativeLog('TFlix: blocked disable-devtool blanking attempt');
+    return null;
+  }
+  return nativeOpen.apply(window, arguments);
+};
+
+window.close = function () {};
+
+window.setTimeout = function (fn, delay) {
+  if (delay === 500 && typeof fn === 'function') {
+    try {
+      if (/theajack|disable-devtool/i.test(Function.prototype.toString.call(fn))) {
+        nativeLog('TFlix: dropped disable-devtool redirect timer');
+        return 0;
+      }
+    } catch (e) {
+      // toString can throw on some proxied/bound functions; fall through and schedule normally
+    }
+  }
+  return nativeSetTimeout.apply(window, arguments);
+};

--- a/mods/userScript.js
+++ b/mods/userScript.js
@@ -1,3 +1,4 @@
+import './antiDevtool.js';
 import 'whatwg-fetch';
 import './spatial-navigation-polyfill.js';
 import './ui.js';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zyrecx/tflix",
   "appName": "TFlix",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "description": "TFlix transforms Cineby.gd into a TV-friendly experience for Samsung TVs running TizenBrew with enhanced remote navigation.",
   "packageType": "mods",
   "websiteURL": "https://www.cineby.gd",


### PR DESCRIPTION
## Summary
- Cineby bundles `disable-devtool@0.3.8`. Its Performance detector false-positives on TV hardware and its stop-after-5s gate misclassifies Tizen as desktop, so the 500ms poll never stops.
- On trigger it navigates the tab to `about:blank` via `window.open('','_self')` — this is the reported black screen in #2.
- `window.DisableDevtool` is not exposed on the page, so the library's own `isSuspend` escape hatch is unavailable.
- Fix stubs `console.log`/`table`/`clear` (resolved per-call by the library, so it works regardless of init order relative to Cineby's bundle) and adds a safety net that blocks the specific `about:blank`/`_self` open pattern and drops the library's 500ms redirect timer.
- Shipped standalone, not bundled with the other known TFlix defects, so we get a clean signal on whether this alone resolves #2 on the TV.

## Test plan
- [x] Publish as 1.4.1, install on TV via TizenBrew
- [ ] Homepage -> click a movie card -> confirm no about:blank
- [ ] Let a movie page idle 2+ minutes (old detector polled forever, so a regression shows up delayed, not immediate)
- [ ] Confirm playback still starts (unrelated to this change, but a basic regression check)

Closes #2